### PR TITLE
Added inital type definitions for usage in Typescript

### DIFF
--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -105,3 +105,30 @@ import apm from 'elastic-apm-node/start'
 
 Then either configure the agent using the environment variables associated with each <<apm-start,config option>>,
 or use the optional <<agent-configuration-file,agent configuration file>>.
+
+[float]
+[[typescript]]
+=== Typescript support
+
+If you are using Typescript, type definitions are provided. Importing the `elastic-apm-node` module:
+
+[source,js]
+----
+import * as apm from 'elastic-apm-node';
+const agent: apm.Agent = apm.start({
+  // add configuration options here -- comes with type safety
+  });
+let started: boolean = agent.isStarted(); //Will return true!
+----
+
+Or if using Babel / ES Modules and the agent needs to be started before other imports use the `elastic-apm-node/start` module: 
+
+[source,js]
+----
+import * as apm from 'elastic-apm-node/start';
+let started: boolean = apm.isStarted(); //Will return true!
+----
+
+
+Then either configure the agent using the environment variables associated with each <<apm-start,config option>>,
+or use the optional <<agent-configuration-file,agent configuration file>>.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,106 @@
+// Type definitions for Elastic APM Node.js Agent 1.12.0
+// Project: https://www.elastic.co/solutions/apm
+// Definitions by: Shahaed Hasan <https://github.com/shahaed>
+// TypeScript Version: 2.7
+
+export const currentTransaction: any;
+
+export function addFilter(filter: (payload: any) => any): void;
+
+export function addTags(tags: any): any;
+
+export function buildSpan(...args: any[]): any;
+
+export function captureError(error: Error | string | object, options?: object, callback?: (err?: any) => any): void;
+
+export function endTransaction(result?: any): any;
+
+export function flush(callback?: any): void;
+
+export function handleUncaughtExceptions(callback?: (err: Error) => any): void;
+
+export function isStarted(): boolean;
+
+// Overloading because Typescript doesn't allow required parameters after an optional one
+export function lambda(handler: any): any;
+export function lambda(type: any, handler: any): any;
+
+export function setCustomContext(context: any): boolean;
+
+export function setTag(name: string, value: string): any;
+
+export function setTransactionName(name: string): any;
+
+export function setUserContext(context: Context): boolean;
+
+export function start(opts?: AgentOptions): Agent;
+
+export function startSpan(name?: string, type?: any): any;
+
+export function startTransaction(name?: string, type?: string): any;
+
+export class Agent {
+
+    currentTransaction: any;
+    logger: any;
+
+    start(opts?: AgentOptions): Agent;
+    isStarted(): boolean;
+    addFilter(filter: (payload: any) => any): void;
+    setUserContext(context: Context): boolean;
+    setCustomContext(context: any): boolean;
+    setTag(name: string, value: string): any;
+    addTags(tags: any): any;
+    captureError(error: Error | string | object, options?: object, callback?: (err?: any) => any): void;
+    startTransaction(name?: string, type?: string): any;
+    endTransaction(result?: any): any;
+    setTransactionName(name: string): any;
+    startSpan(name?: string, type?: any): any;
+    handleUncaughtExceptions(callback?: (err: Error) => any): any;
+    flush(callback?: any): any;
+    lambda(handler: any): any;
+    lambda(type: any, handler: any): any;
+}
+
+interface AgentOptions {
+    serviceName?: string;
+    secretToken?: string;
+    serverUrl?: string;
+    verifyServerCert?: boolean;
+    serviceVersion?: string;
+    active?: boolean;
+    instrument?: boolean;
+    asyncHooks?: boolean;
+    ignoreUrls?: (RegExp | string)[];
+    ignoreUserAgents?: (RegExp | string)[];
+    captureBody?: string;
+    errorOnAbortedRequests?: boolean;
+    abortedErrorThreshold?: number;
+    transactionSampleRate?: number;
+    hostname?: string;
+    frameworkName?: string;
+    frameworkVersion?: string;
+    logLevel?: string;
+    logger?: any;
+    captureExceptions?: boolean;
+    captureErrorLogStackTraces?: string;
+    captureSpanStackTraces?: boolean;
+    sourceLinesErrorAppFrames?: number;
+    sourceLinesErrorLibraryFrames?: number;
+    sourceLinesSpanAppFrames?: number;
+    sourceLinesSpanLibraryFrames?: number;
+    errorMessageMaxLength?: number;
+    stackTraceLimit?: number;
+    transactionMaxSpans?: number;
+    flushInterval?: number;
+    serverTimeout?: number;
+    maxQueueSize?: number;
+    filterHttpHeaders?: boolean;
+    disableInstrumentations?: string;
+}
+
+interface Context {
+    id?: string;
+    username?: string;
+    email?: string;
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.12.0",
   "description": "The official Elastic APM agent for Node.js",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "docs": "./docs/scripts/build_docs.sh apm-agent-nodejs ./docs ./build",
     "lint": "standard",

--- a/start.d.ts
+++ b/start.d.ts
@@ -1,0 +1,5 @@
+// Type definitions for Babel / ES Modules support
+// Documentation: https://www.elastic.co/guide/en/apm/agent/nodejs/1.x/advanced-setup.html#es-modules
+// Usage: `import * as apm from 'elastic-apm-node/start'`
+import * as agent from './';
+export = agent;


### PR DESCRIPTION
Added type definitions for the `Agent` object exposed by the elastic-apm-node module.

The Agent options and all functions from the [API docs](https://www.elastic.co/guide/en/apm/agent/nodejs/1.x/agent-api.html#apm-capture-error) are typed to the best of my knowledge from the information in the docs/code.

TODO: There are still a lot of `any` types where the types were not clear.
- [ ] Replace all `any` types that can be further typed.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update documentation
